### PR TITLE
Add netstandard2.1 target

### DIFF
--- a/TupleAsJsonArray/TupleAsJsonArray.csproj
+++ b/TupleAsJsonArray/TupleAsJsonArray.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Alexandre Rogozine</Authors>
     <Description>Convert C# Tuple to/from JSON Array</Description>
@@ -16,8 +16,8 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile></DocumentationFile>
-  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+  </ItemGroup>
 
 </Project>

--- a/TupleAsJsonArray/TupleAsJsonArray.csproj
+++ b/TupleAsJsonArray/TupleAsJsonArray.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 

--- a/TupleJsonUnitTests/TupleJsonUnitTests.csproj
+++ b/TupleJsonUnitTests/TupleJsonUnitTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Targeting netstandard2.0 needs too many code changes. Targeting netstandard2.1 instead. Closes #1.

NuGet package for whoever needs it while PR is not yet merged: 
[TupleAsJsonArray.1.0.2.zip](https://github.com/arogozine/TupleAsJsonArray/files/5819158/TupleAsJsonArray.1.0.2.zip) (Rename extension .zip to .nupkg, GitHub does not support uploading .nupkg files directly)
