### PR TITLE
Fix handling of large streams

### DIFF
--- a/TupleAsJsonArray/Converters/TupleConverterBase.cs
+++ b/TupleAsJsonArray/Converters/TupleConverterBase.cs
@@ -24,16 +24,7 @@ namespace TupleAsJsonArray
         /// <param name="options">Existing Options</param>
         protected void WriteValue<T>(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
-            var converter = (JsonConverter<T>)options.GetConverter(typeof(T));
-
-            if (converter == null)
-            {
-                JsonSerializer.Serialize(writer, value, options);
-            }
-            else
-            {
-                converter.Write(writer, value, options);
-            }
+            JsonSerializer.Serialize(writer, value, options);
         }
 
         /// <summary>
@@ -45,16 +36,7 @@ namespace TupleAsJsonArray
         /// <returns>Deserialized Value</returns>
         protected T ReadValue<T>(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
-            var converter = (JsonConverter<T>)options.GetConverter(typeof(T));
-
-            if (converter == null)
-            {
-                return JsonSerializer.Deserialize<T>(ref reader, options);
-            }
-            else
-            {
-                return converter.Read(ref reader, typeof(T), options);
-            }
+            return JsonSerializer.Deserialize<T>(ref reader, options);
         }
     }
 }

--- a/TupleJsonUnitTests/TupleJsonUnitTests.csproj
+++ b/TupleJsonUnitTests/TupleJsonUnitTests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello @arogozine, we use this library extensively and ran into the below exception when deserializing large payloads with some unusually shaped records:
```
System.Text.Json.JsonException: The JSON value could not be converted to System.ValueTuple`2[System.Guid,TupleJsonUnitTests.UnitTests+DataRecord]. Path: $[0] | LineNumber: 0 | BytePositionInLine: 81. ---> System.InvalidOperationException: Cannot skip tokens on partial JSON. Either get the whole payload and create a Utf8JsonReader instance where isFinalBlock is true or call TrySkip.
    at System.Text.Json.Utf8JsonReader.Skip()
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonResumableConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   at TupleAsJsonArray.TupleConverterBase`1.ReadValue[T](Utf8JsonReader& reader, JsonSerializerOptions options)
   at TupleAsJsonArray.ValueTupleConverter`2.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   ```
The issue only appears with very large entity counts and when using a stream.

Changing the implementation to always delegate the deserialization/serialization to the serializer instead of pulling out a converter appears to fix this issue. I'm not sure if this has an unintended side-effects but the tests continue to pass.
